### PR TITLE
Fix location of scipy factorial function

### DIFF
--- a/gufm1/gufm1.py
+++ b/gufm1/gufm1.py
@@ -5,7 +5,7 @@ Created on Tue Feb 23 11:52:39 2016
 @author: nknezek
 """
 
-from scipy.misc import factorial as _factorial
+from scipy.special import factorial as _factorial
 from scipy.special import lpmv as _lpmv
 from numpy import sin as _sin
 from numpy import cos as _cos


### PR DESCRIPTION
The SciPy factorial function is not in misc anymore, so I've adjusted the import statement. This change is required to run the Jupyter Notebook in /examples.

Thank you for writing this package, and if I end up using it in a project I might submit another PR with further updates!